### PR TITLE
Enable use of unix_socket_path feature

### DIFF
--- a/nydus/db/backends/redis.py
+++ b/nydus/db/backends/redis.py
@@ -33,10 +33,12 @@ class Redis(BaseConnection):
     retryable_exceptions = frozenset([RedisError])
     supports_pipelines = True
 
-    def __init__(self, host='localhost', port=6379, db=0, timeout=None, **options):
+    def __init__(self, host='localhost', port=6379, db=0, timeout=None,
+        unix_socket_path=None, **options):
         self.host = host
         self.port = port
         self.db = db
+        self.unix_socket_path = unix_socket_path
         self.timeout = timeout
         super(Redis, self).__init__(**options)
 
@@ -47,7 +49,8 @@ class Redis(BaseConnection):
         return "redis://%(host)s:%(port)s/%(db)s" % mapping
 
     def connect(self):
-        return RedisClient(host=self.host, port=self.port, db=self.db, socket_timeout=self.timeout)
+        return RedisClient(host=self.host, port=self.port, db=self.db,
+            socket_timeout=self.timeout, unix_socket_path=self.unix_socket_path)
 
     def disconnect(self):
         self.connection.disconnect()


### PR DESCRIPTION
Specify 'unix_socket_path' as a configuration option for a host to by unix socket rather than TCP.

This change simply adds unix_socket_path as a redis configuration option and passes it on to redis-py, which will only use its value (and ignore host/port) if it is specified. (so forwarding the option is sufficient, nydus doesn't need logic to decide whether to send the option)
