### PR TITLE
Fail silently support

### DIFF
--- a/nydus/db/backends/base.py
+++ b/nydus/db/backends/base.py
@@ -44,6 +44,7 @@ class BaseConnection(object):
     def __init__(self, num, **options):
         self._connection = None
         self.num = num
+        self.options = options
 
     @property
     def identifier(self):

--- a/nydus/db/base.py
+++ b/nydus/db/base.py
@@ -9,7 +9,8 @@ nydus.db.base
 from collections import defaultdict
 from nydus.db.routers import BaseRouter
 from nydus.utils import import_string, ThreadPool
-
+import logging
+logger = logging.getLogger(__name__)
 
 def create_cluster(settings):
     """
@@ -79,20 +80,38 @@ class Cluster(object):
 
     def _execute(self, attr, args, kwargs):
         connections = self._connections_for(attr, *args, **kwargs)
-
         results = []
         for conn in connections:
-            print conn
+            conn_options = conn.options
+            fail_silently = conn_options.get('fail_silently', False)
+            
             for retry in xrange(self.max_connection_retries):
                 try:
                     results.append(getattr(conn, attr)(*args, **kwargs))
                 except tuple(conn.retryable_exceptions), e:
+                    #retry, raise an error or fail silently
+                    error = None
                     if not self.router.retryable:
-                        raise e
+                        error = e
                     elif retry == self.max_connection_retries - 1:
-                        raise self.MaxRetriesExceededError(e)
+                        error = self.MaxRetriesExceededError(e)
                     else:
                         conn = self._connections_for(attr, retry_for=conn.num, *args, **kwargs)[0]
+                        
+                    if error and fail_silently:
+                        #fail silently by returning None, usefull for cache like usage of redis
+                        if self.router.retryable:
+                            logger.error('failing silently after %s retries for conn %s with command %s', self.max_connection_retries, conn, attr)
+                        else:
+                            logger.error('failing silently for conn %s with command %s', conn, attr)
+                        results = [None]
+                        break
+                    else:
+                        raise error
+                    
+                    #going for another retry
+                    logger.warn('retrying connection %s with command %s', conn, attr)
+                    
                 else:
                     break
 


### PR DESCRIPTION
When using redis as a cache you don't always want your app to fail if redis is unavailable.
This pull requests adds support for a fail_silently parameter.
Allowing your app to gracefully fall back to the database instead of breaking.
The default behaviour is unchanged:

```
        'redis': {
            'engine': 'nydus.db.backends.redis.Redis',
            'router': 'nydus.db.routers.redis.PrefixPartitionRouter',
            'hosts': {
                'hash:entity:': {'db': 0, 'host': 'entities.redis.goteam.be', 'port': 6379, 'fail_silently': True},
            }
        },
```

Cheers,
Thierry Schellenbach
CTO / Co-Founder
Fashiolista.com
