### PR TITLE
Improvement in add_node calls

### DIFF
--- a/nydus/db/routers/keyvalue.py
+++ b/nydus/db/routers/keyvalue.py
@@ -45,7 +45,9 @@ class ConsistentHashingRouter(RoundRobinRouter):
 
     def mark_connection_up(self, db_num):
         db_num = self.ensure_db_num(db_num)
-        self._hash.add_node(self._db_num_id_map[db_num])
+        node_key = self._db_num_id_map[db_num]
+        if self._hash.get_node(node_key) is None:
+            self._hash.add_node(node_key)
 
         super(ConsistentHashingRouter, self).mark_connection_up(db_num)
 


### PR DESCRIPTION
I did this change for performance improvement.
I think it's not necessary to add the node key to hash if the node key was already added.
After this change, the redis access time decreased 75%.
@dcramer, I didn't found any test case where the node key was None.
What's the better way to test it?
