### PR TITLE
Change the initialization for the Riak backend so it is consistent with ...

### DIFF
--- a/nydus/db/backends/riak.py
+++ b/nydus/db/backends/riak.py
@@ -22,12 +22,13 @@ class Riak(BaseConnection):
     supports_pipelines = False
 
     def __init__(self, host='127.0.0.1', port=8098, prefix='riak', mapred_prefix='mapred', client_id=None, **options):
+
         self.host = host
         self.port = port
         self.prefix = prefix
         self.mapred_prefix = mapred_prefix
         self.client_id = client_id
-        super(Riak, self).__init__(**options)
+        super(Riak, self).__init__(num)
 
     @property
     def identifier(self):

--- a/tests/nydus/db/backends/riak/tests.py
+++ b/tests/nydus/db/backends/riak/tests.py
@@ -26,8 +26,8 @@ class RiakTest(BaseTest):
             'client_id': 'MjgxMDg2MzQx',
         }
 
-        self.conn = Riak(num=0)
-        self.modified_conn = Riak(num=1, **self.modified_props)
+        self.conn = Riak(0)
+        self.modified_conn = Riak(1, **self.modified_props)
 
     def test_init_defaults(self):
         self.assertDictContainsSubset(self.expected_defaults, self.conn.__dict__)


### PR DESCRIPTION
...how the other backends are being initialized.

Otherwise we get:

TypeError: **init**() got multiple values for keyword argument 'XXXXX'

When nydus tries to initialize the backend. Fixed tests to reflect this change.
